### PR TITLE
Create macro dir before using it in code

### DIFF
--- a/install.py
+++ b/install.py
@@ -86,12 +86,13 @@ def find_macro_file():
     """Returns path of existing installed macro or an unused macro number file."""
 
     number = 0
+    if not os.path.exists(CONFIG_DIR):
+        os.makedirs(CONFIG_DIR)
     while True:
         filename = 'Macro_{}.txsMacro'.format(number)
         macroFile = os.path.join(CONFIG_DIR, filename)
         if not os.path.exists(macroFile):
             print('Installing WakaTime macro {}.'.format(macroFile))
-            os.makedirs(CONFIG_DIR)
             return macroFile
         with open(macroFile, 'r', encoding='utf-8') as fh:
             macro = json.load(fh)


### PR DESCRIPTION
When I tried installing the plugin I got `FileExistsError: [Errno 17] File exists` at line 94 of install.py

To remedy this problem I checked for the existence of the folder before executing `os.makedirs(CONFIG_DIR)`. To prevent this check from happening for every file I also moved it outside of the while loop.